### PR TITLE
FIX: APIview에서 GenericAPIView로 변경 후 Swagger 문서 적용

### DIFF
--- a/bear/urls.py
+++ b/bear/urls.py
@@ -13,12 +13,36 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+from django.conf.urls import url
 from django.contrib import admin
 from django.urls import path, include
 import kpi.urls, restaurant.urls
+from rest_framework.permissions import AllowAny
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
+schema_url_patterns = [
+    path('api/v1/restaurant/', include(restaurant.urls)),
+    path('api/v1/kpi/', include(kpi.urls)),
+]
+
+schema_view_v1 = get_schema_view(
+    openapi.Info(
+        title="Bear APIs",
+        default_version='v1',
+        description="베어 로보틱스 기술 과제 swagger 문서",
+        terms_of_service="https://github.com/2nd-wanted-pre-onboarding-team-A/Bear-Robotics-Wanted-A",
+    ),
+    public=True,
+    permission_classes=(AllowAny,),
+    patterns=schema_url_patterns,
+)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v1/restaurant/', include(restaurant.urls)),
     path('api/v1/kpi/', include(kpi.urls)),
+    url(r'^swagger(?P<format>\.json|\.yaml)$', schema_view_v1.without_ui(cache_timeout=0), name='schema-json'),
+    url(r'^swagger/$', schema_view_v1.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    url(r'^redoc/$', schema_view_v1.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
 ]

--- a/restaurant/views.py
+++ b/restaurant/views.py
@@ -6,13 +6,17 @@ from .serializers import (
     RestaurantListSerializer, RestaurantDetailSerializer,
 )
 from django.shortcuts import get_list_or_404, get_object_or_404
-from rest_framework.views import APIView
+from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from rest_framework import status
 
 
+
 # PosData get, post
-class PosDataListView(APIView):
+class PosDataListView(GenericAPIView):
+    queryset = PosResultData.objects.all()
+    serializer_class = PosDataListSerializer
+
     def get(self, request, format=None):
         pos_data = get_list_or_404(PosResultData)
         serializer = PosDataListSerializer(pos_data, many=True)
@@ -25,7 +29,10 @@ class PosDataListView(APIView):
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-class PosDataDetailView(APIView):
+class PosDataDetailView(GenericAPIView):
+    queryset = PosResultData.objects.all()
+    serializer_class = PosDataDetailSerializer
+
     def get(self, request, pk, format=None):
         pos_data = get_object_or_404(PosResultData, pk=pk)
         serializer = PosDataDetailSerializer(pos_data)
@@ -33,7 +40,10 @@ class PosDataDetailView(APIView):
 
 # 개발용으로 만들어둔거
 # 레스토랑 데이타 get, post, update, delete
-class RestaurantListView(APIView):
+class RestaurantListView(GenericAPIView):
+    queryset = Restaurant.objects.all()
+    serializer_class = RestaurantListSerializer
+
     def get(self, request, format=None):
         restaurants = get_list_or_404(Restaurant)
         serializer = RestaurantListSerializer(restaurants, many=True)
@@ -46,14 +56,17 @@ class RestaurantListView(APIView):
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-class RestaurantDetailView(APIView):
+class RestaurantDetailView(GenericAPIView):
+    queryset = Restaurant.objects.all()
+    serializer_class = RestaurantDetailSerializer
+
     def get(self, request, pk, format=None):
         restaurant = get_object_or_404(Restaurant, pk=pk)
         serializer = RestaurantDetailSerializer(restaurant)
         return Response(serializer.data, status=status.HTTP_200_OK)
         
-    def put(self, request, pk, format=None):
-        restaurant = get_object_or_404(Restaurant, pk=pk)
+    def put(self, request, *args, **kwargs):
+        restaurant = get_object_or_404(Restaurant, pk=kwargs['pk'])
         serializer = RestaurantDetailSerializer(restaurant, data=request.data)
         if serializer.is_valid():
             serializer.save()


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- Swagger 문서 적용

<br />

## :: 구현 사항 설명
- 기존 APIView에서 Swagger 문서 적용을 위해 GenericAPIView로 수정했어요.
- Swagger에 나타낼 url을 포함시켰어요.
- 각 api마다 Swagger 문서에서 테스트할 수 있도록 serializer와 연결하였어요.
- 서버 실행 후 `http://127.0.0.1:8000/swagger/` 경로로 Swagger 문서에 접근할 수 있어요



<br />

## :: ISSUE


<br />