### PR TITLE
FIX: restaurant group에 대한 validation 함수 제거

### DIFF
--- a/kpi/views.py
+++ b/kpi/views.py
@@ -87,7 +87,6 @@ class RestaurantKpiView(APIView):
 
         if (restaurant_group is not None):
             check_none_necessary_string(restaurant_group, 'restaurant_group')
-            is_zero_or_more_numbers(restaurant_group, 'restaurant_group')
             restaurant = Restaurant.objects.filter(group=restaurant_group).first()
             if not restaurant:
                 return Response(


### PR DESCRIPTION
## :: 최근 작업 주제
- [ ] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 리뷰 반영

<br />

## :: 구현 사항 설명
- 검색 파라메터인 group에 대한 `is_zero_or_more_numbers`validation 함수 삭제
- `string` 이므로 숫자인지 판별하는 함수를 뺐습니다!



<br />

## :: ISSUE


<br />